### PR TITLE
fix idrnet on fp16 mixed precision

### DIFF
--- a/ssseg/modules/models/segmentors/idrnet/idrnet.py
+++ b/ssseg/modules/models/segmentors/idrnet/idrnet.py
@@ -323,7 +323,7 @@ class IDRNet(BaseSegmentor):
                 cls_contexts = torch.stack(cls_contexts)
                 selected_class_relations = torch.cat(selected_class_relations, dim=1)
                 if remove_negative_cls_relation:
-                    selected_class_relations[selected_class_relations <= 0] = -1e16
+                    selected_class_relations[selected_class_relations <= 0] = -1e4
                 selected_class_relations = F.softmax(selected_class_relations, dim=1)
                 selected_class_relations_tmp = []
                 for cls_id in valid_clsids:


### PR DESCRIPTION
```
    File "/oncology/experimental/users/sieun/segmentation_framework/sssegmentation.py", lin
e 271, in get_logits                                                                       
      x, seg_out = self._run_segmentor(x, **kwargs)                                        
    File "/oncology/experimental/users/sieun/segmentation_framework/sssegmentation.py", lin
e 234, in _run_segmentor                                                                   
      out = self.segmentor(data_meta)                                                      
    File "/home/sieunp/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", lin
e 1736, in _wrapped_call_impl                                                              
      return self._call_impl(*args, **kwargs)                                              
    File "/home/sieunp/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", lin
e 1747, in _call_impl                                                                      
      return forward_call(*args, **kwargs)                                                 
    File "/home/sieunp/.local/lib/python3.10/site-packages/ssseg/modules/models/segmentors/
idrnet/idrnet.py", line 159, in forward                                                    
      id_context_mean, valid_clsids_batch = self.obtainidcontext(feats_withdl, preds_stage1
, self.class_relations_mean)                                                               
    File "/home/sieunp/.local/lib/python3.10/site-packages/ssseg/modules/models/segmentors/
idrnet/idrnet.py", line 326, in obtainidcontext                                            
      selected_class_relations[selected_class_relations <= 0] = -1e16                       
  RuntimeError: value cannot be converted to type at::Half without overflow                
```

there is a bug where when IDRnet is run with amp fp16, the placeholder value `-1e16` is out of bounds of fp16. Reducing to `-1e4` fixes the bug.