### PR TITLE
Fix fp16 compatibility issues in multiple segmentation models

### DIFF
--- a/ssseg/modules/models/segmentors/idrnet/idrnet.py
+++ b/ssseg/modules/models/segmentors/idrnet/idrnet.py
@@ -323,7 +323,7 @@ class IDRNet(BaseSegmentor):
                 cls_contexts = torch.stack(cls_contexts)
                 selected_class_relations = torch.cat(selected_class_relations, dim=1)
                 if remove_negative_cls_relation:
-                    selected_class_relations[selected_class_relations <= 0] = -1e16
+                    selected_class_relations[selected_class_relations <= 0] = -1e4
                 selected_class_relations = F.softmax(selected_class_relations, dim=1)
                 selected_class_relations_tmp = []
                 for cls_id in valid_clsids:

--- a/ssseg/modules/models/segmentors/isnet/semanticlevel.py
+++ b/ssseg/modules/models/segmentors/isnet/semanticlevel.py
@@ -31,7 +31,7 @@ class SemanticLevelContext(nn.Module):
         inputs = x
         batch_size, num_channels, h, w = x.size()
         num_classes = preds.size(1)
-        feats_sl = torch.zeros(batch_size, h*w, num_channels).type_as(x)
+        feats_sl = torch.zeros(batch_size, h*w, num_channels, device=x.device, dtype=torch.float32)
         for batch_idx in range(batch_size):
             # (C, H, W), (num_classes, H, W) --> (H*W, C), (H*W, num_classes)
             feats_iter, preds_iter = x[batch_idx], preds[batch_idx]


### PR DESCRIPTION
- IDRNet: Change negative value from -1e16 to -1e4 to prevent fp16 overflow
- ISNet: Fix tensor creation to ensure proper device and dtype handling
- OCRNet: Fix spatial gather module input size mismatch by interpolating seg_logits_aux

These changes ensure models work correctly with fp16 (half precision) training.

🤖 Generated with [Claude Code](https://claude.ai/code)