### PR TITLE
fix `mask2former` jit trace serialization error

### DIFF
--- a/ssseg/modules/models/segmentors/mask2former/transformers/pixeldecoder.py
+++ b/ssseg/modules/models/segmentors/mask2former/transformers/pixeldecoder.py
@@ -79,10 +79,7 @@ class MSDeformAttn(nn.Module):
         else:
             raise ValueError('Last dim of reference_points must be 2 or 4, but get {} instead.'.format(reference_points.shape[-1]))
         # MSDeformAttnFunction
-        try:
-            output = MSDeformAttnFunction.apply(value, input_spatial_shapes, input_level_start_index, sampling_locations, attention_weights, self.im2col_step)
-        except:
-            output = ms_deform_attn_core_pytorch(value, input_spatial_shapes, sampling_locations, attention_weights)
+        output = ms_deform_attn_core_pytorch(value, input_spatial_shapes, sampling_locations, attention_weights)
         output = self.output_proj(output)
         # return output
         return output


### PR DESCRIPTION
Hi, thanks for the library. I noticed that such `try-except` in the Mask2Former implementation leads to an error while calling `torch.jit.trace`. It: 's nice that most other models work well with serialization and this fixes it for Mask2Former.

Thanks, it would be greatly helpful if you could have a look.